### PR TITLE
Add assignPublicIp option to true for FargateService for pulling secrets/images

### DIFF
--- a/lib/github-actions-runner-stack.ts
+++ b/lib/github-actions-runner-stack.ts
@@ -56,6 +56,7 @@ export class GithubActionsRunnerStack extends cdk.Stack {
         cluster,
         taskDefinition,
         platformVersion: FargatePlatformVersion.VERSION1_4,
+        assignPublicIp: true
       }
     );
   }


### PR DESCRIPTION
I tried deploying this but failed with below error.

```
ResourceInitializationError: unable to pull secrets or registry auth
```

Fargate platform version is specified 1.4, and I solved this issue by assigning public ip address to pull secrets

[Reference]
https://stackoverflow.com/questions/61265108/aws-ecs-fargate-resourceinitializationerror-unable-to-pull-secrets-or-registry

<img width="682" alt="スクリーンショット 2020-10-06 19 24 55" src="https://user-images.githubusercontent.com/8651308/95190082-b89da880-0809-11eb-9468-ecf7d5407dd9.png">